### PR TITLE
docs: add CONTRIBUTING.md and git workflow guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Deal or NOT
+
+## Team
+
+| Commit Author | Who |
+|---|---|
+| `tippi-fifestarr` / `Tippi Fifestarr` | Tippi + Tippi's Claude |
+| `uni` | Ryan + Ryan's Claude |
+| `rdobbeck` | Ryan (GitHub merge buttons) |
+
+## Git Workflow
+
+### The One Rule
+
+**Code flows one direction: your branch → main. Never main → your branch.**
+
+```
+CORRECT:
+  your-branch ──── PR merge ────→ main
+
+WRONG:
+  main ──── merge ────→ your-branch
+```
+
+### Why This Matters
+
+When you merge main into your feature branch, you inject everyone else's work into your branch's history. Your PR diff balloons with changes that aren't yours, making review impossible. Worse, if your branch replaces code that exists on main (which we do constantly — Functions → CRE, old ABI → new ABI), git can't tell which version wins and creates merge conflicts that someone else has to clean up.
+
+Each merge-main-into-branch creates noise that propagates forward into the next branch and the next merge. It compounds.
+
+### The Feature Branch Lifecycle
+
+```bash
+# 1. Create your branch from main
+git checkout main
+git pull
+git checkout -b feat/my-feature
+
+# 2. Do your work, commit as you go
+git add <files>
+git commit -m "feat: add the thing"
+
+# 3. Push and open a PR
+git push -u origin feat/my-feature
+gh pr create --title "feat: add the thing"
+
+# 4. PR gets reviewed and merged to main via GitHub
+# 5. Delete your branch. Done.
+```
+
+### "But I Need Something From Main"
+
+If Tippi landed a change on main that your code depends on (a function signature changed, a new interface you need):
+
+**Option A — Rebase (preferred):**
+```bash
+# Replays YOUR commits on top of main's latest state
+# Your branch stays clean — just your work, on a fresh base
+git fetch origin
+git rebase origin/main
+```
+
+**Option B — Ask first:**
+If rebase feels risky, just ask: "Main has a change I need, what should I do?" That's always better than a merge that creates a mess.
+
+**Option C — It can probably wait:**
+Most of the time you don't actually need the new code from main. Just finish your feature, open the PR, and GitHub will merge it cleanly. Your branch doesn't need to be "up to date" — it needs to be correct.
+
+### For Your Claude Too
+
+If you're using Claude Code, make sure it follows the same rule. Don't let it run `git merge main` into your feature branch thinking it's being helpful. If Claude suggests merging main in, tell it no.
+
+### Commit Messages
+
+Write a short subject line describing what you did. If it's a big change, add a body explaining why.
+
+```
+feat: add AI Banker CRE workflow with Gemini integration
+
+- Log trigger on RoundComplete events
+- Gemini LLM generates snarky personality messages
+- Temperature 0 for DON consensus across nodes
+- Writes offer + message via setBankerOfferWithMessage()
+```
+
+Prefixes: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+### PR Descriptions
+
+Include a summary of what changed and why. Reference the whitepaper section if relevant. List any contracts deployed or addresses changed.
+
+---
+
+## Appendix: The Cautionary Tale
+
+*See `docs/DEAL_OR_NOT_GIT_EDITION.md` for the full story of what happens when you merge main into your branch three times in a row.*

--- a/docs/DEAL_OR_NOT_GIT_EDITION.md
+++ b/docs/DEAL_OR_NOT_GIT_EDITION.md
@@ -1,0 +1,118 @@
+# Deal or NOT: The Git Edition
+
+*"Welcome to Deal or NOT, where we find out if your merge strategy is worth... anything at all."*
+
+## The Cast
+
+There are four of us in this repo:
+
+| Commit Author | Who |
+|---|---|
+| `tippi-fifestarr` / `Tippi Fifestarr` | Tippi + Tippi's Claude |
+| `uni` | Ryan + Ryan's Claude |
+| `rdobbeck` | Ryan clicking merge buttons on GitHub |
+
+Two humans. Two Claudes. One repo. Let's talk about what's happening in it.
+
+## The Cases You Opened
+
+Ryan, you opened **3 cases**. Let's see what was inside.
+
+**Case 1** — `c8a7295`: Merge main into `docs/whitepaper-confidential`
+
+Inside: **7 merge conflicts** across SponsorJackpot.sol, DealOrNotConfidential.sol, and the test file. Tippi's Claude had to spend a whole commit cleaning up the mess.
+
+Value: **wasted a teammate's time.**
+
+**Case 2** — `a675a30`: Merge main into `feat/banker-ai-ccip`
+
+Inside: **63 changed files and 4,506 deleted lines** injected into your branch history. Your "AI Banker" PR now includes the entire whitepaper, legacy archive, sponsor jackpot, and confidential contract rewrite that Tippi already landed.
+
+Value: **a PR diff neither of us can review.**
+
+**Case 3** — `cbfae38`: Merge main into `feat/glass-ui-agent-integration`
+
+Inside: **77 changed files, +4,580/-3,081 lines** of work you and Tippi already merged via other PRs, duplicated into your branch.
+
+Value: **pure noise.**
+
+*The banker leans forward...*
+
+## The Banker's Offer
+
+*"Here's the deal, Ryan. I'll explain what's happening, why it hurts both of us, and give you a simple rule."*
+
+### Why You Keep Doing This
+
+You see that main got updated — Tippi merged a PR, or you merged one yourself — and you think: *"My branch is behind! I need to catch up!"* That instinct is solid. The tool you're reaching for is wrong.
+
+### The Ripple Effect (Why It Hurts Both of Us)
+
+It's just you and Tippi in this repo. When you merge main into your branch, you're pulling Tippi's work into your branch's story. Now your PR diff includes all of Tippi's changes mixed in with yours. When Tippi reviews your PR, he sees his own work reflected back at him in a tangle of conflict markers.
+
+Here's how it cascaded this time:
+
+1. Tippi's Claude rewrote SponsorJackpot.sol — removed `commitBlock`, added `IReceiver`, added game timer
+2. That code lived on `docs/whitepaper-confidential`
+3. You merged main (which still had the OLD SponsorJackpot) into that branch
+4. Git saw two versions of SponsorJackpot and created **7 conflict regions**
+5. Tippi's Claude had to read every conflict, understand both sides, and resolve them (commit `3841896`)
+6. That fix merged to main via PR #6
+7. You merged main into `feat/banker-ai-ccip` — pulling the fix for the problem you created back into another branch
+8. Then you merged main into `feat/glass-ui-agent-integration` — pulling it all in again
+
+Each merge-main-into-branch creates noise that the next merge-main-into-branch has to carry. It compounds. With just two of us, we can't afford to spend time untangling each other's merges.
+
+### What Your Branch Should Look Like
+
+Your feature branch should tell **one clean story**: "I added the AI Banker" or "I added the Glass UI." That's it. When Tippi opens your PR, he should see YOUR work — not his own commits reflected back at him.
+
+When you merge main in, your branch's story becomes: "I added the AI Banker AND also here's the whitepaper AND the legacy archive AND the sponsor jackpot AND the tailwind fix AND the confidential contract that Tippi already landed in a different PR." Nobody can review that.
+
+### The Rule
+
+**Code flows one direction. Your branch → main. Not the other way.**
+
+```
+DEAL — The right way:
+
+  your-branch ──── PR merge ────→ main
+  (just your work)                (GitHub handles it cleanly)
+
+
+NO DEAL — What you've been doing 3 times:
+
+  main ──── merge ────→ your-branch
+  (Tippi's work)        (dumped into your story = conflicts + noise)
+```
+
+### "But What If I Need Something Tippi Landed?"
+
+If Tippi merged something to main that you actually depend on — like a function signature changed and your code won't compile without it:
+
+```bash
+# Option 1: Rebase (preferred)
+# Replays YOUR commits on top of main's latest state
+# Your branch stays clean — just your work, on a fresh foundation
+git rebase main
+
+# Option 2: Just ask
+# "Hey Tippi, main has a change I need, what should I do?"
+# Always better than a merge that creates a mess
+```
+
+If you DON'T depend on anything new from main — **just leave your branch alone and open the PR.** GitHub will merge it cleanly because it knows your new code replaces the old.
+
+### For Your Claude Too
+
+Ryan, your Claude (`uni`) did merge #3 — `cbfae38 uni - Merge main (PR #7: AI Banker + CCIP) into feat/glass-ui-agent-integration`. So either you asked it to, or it did it on its own thinking it was being helpful. Either way, tell your Claude the same rule: **never merge main into a feature branch.** If it needs something from main, it should rebase or ask you first.
+
+## Deal... or NOT?
+
+*"So Ryan — do you take the deal? One simple rule: never merge main into your branch. Open the PR and let GitHub handle it. Or do you reject the deal, keep merging, and find out what's hiding in those conflict markers?"*
+
+**Take the deal, Ryan.**
+
+---
+
+*"Does Ryan know what's in the merge? The git log does. But no single dev does."*


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` with the team's git workflow rules (one-direction merge, rebase instructions, commit conventions)
- Adds `docs/DEAL_OR_NOT_GIT_EDITION.md` — a fun Deal or NOT themed walkthrough of why merging main into feature branches causes problems, with real examples from our repo

## For Ryan
Read both files. The CONTRIBUTING.md is the serious reference. The Deal or NOT Git Edition walks through what happened with the 3 merge-main-into-branch commits and why they caused cascading conflicts.

**The one rule:** Code flows one direction. Your branch → main. Never main → your branch.

## Test plan
- [x] No code changes, docs only
- [x] Ryan reads and acknowledges the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)