### PR TITLE
feat: Confidential HTTP entropy + Gemini, fix CRE scripts, E2E verified

### DIFF
--- a/prototype/contracts/TESTCASE_CONFIDENTIAL.md
+++ b/prototype/contracts/TESTCASE_CONFIDENTIAL.md
@@ -1,0 +1,212 @@
+# Testing DealOrNotConfidential — End-to-End with CRE
+
+Full story of getting `cre simulate --broadcast` working, every gotcha we hit, and how to reproduce a clean E2E test from scratch.
+
+## Prerequisites
+
+1. **CRE CLI** installed (`cre --version` → 1.2.0+)
+2. **Foundry** installed (`cast --version`)
+3. **Bun** installed for workflow deps (`bun --version`)
+4. **Gemini API key** — get one at https://aistudio.google.com/apikey
+
+## One-Time Setup
+
+```bash
+cd prototype
+
+# Install workflow dependencies (all 4 workflows)
+for wf in workflows/confidential-reveal workflows/banker-ai workflows/sponsor-jackpot workflows/game-timer; do
+  (cd "$wf" && bun install)
+done
+
+# Create workflows/.env with your Gemini key (gitignored)
+cat > workflows/.env << 'EOF'
+GEMINI_API_KEY_ALL=<your-gemini-key>
+CRE_SECRET_ALL=deal-or-not-enclave-entropy-v1
+EOF
+
+# CRE login (one-time)
+cre login
+```
+
+## Critical: Set CRE Forwarder After Every Deploy
+
+**This is the #1 thing that silently breaks everything.**
+
+After deploying or redeploying `DealOrNotConfidential`, you MUST set the CRE forwarder to the MockKeystoneForwarder:
+
+```bash
+source scripts/env.sh
+
+# Set forwarder on game contract
+cast send "$CONTRACT" "setCREForwarder(address)" 0x82300bd7c3958625581cc2F77bC6464dcEcDF3e5 \
+  --private-key "$DEPLOYER_KEY" --rpc-url "$RPC_URL"
+
+# Verify
+cast call "$CONTRACT" "creForwarder()(address)" --rpc-url "$RPC_URL"
+# Must return: 0x82300bd7c3958625581cc2F77bC6464dcEcDF3e5
+```
+
+**What happens if you forget**: The MockKeystoneForwarder calls `onReport()` on your contract. Inside `onReport()`, `msg.sender` is the forwarder address. If `creForwarder` points to the deployer instead, the contract reverts with `NotCREForwarder()` (selector `0x1a20e753`). The forwarder TX shows `status: 1` but emits `result: false` in its event data. This looks like a replay protection issue but it's just a wrong address.
+
+**The function is `setCREForwarder` (NOT `setForwarder`).**
+
+**How to debug**: Run `cast run <forwarder-tx-hash> --rpc-url $RPC_URL` to see the internal trace and revert reason.
+
+## Full E2E Test (CLI Mode)
+
+```bash
+cd prototype
+source scripts/env.sh
+
+# 1. Create game
+zsh scripts/play-game.sh create
+# Wait ~10s for VRF callback
+
+# 2. Check state — should be Created (1)
+zsh scripts/play-game.sh state <GID>
+
+# 3. Pick your case
+zsh scripts/play-game.sh pick <GID> 3
+
+# 4. Launch CRE auto-support (runs in background)
+zsh scripts/cre-support.sh <GID> &
+
+# 5. Open cases, reject offers, repeat
+zsh scripts/play-game.sh open <GID> 0
+# Wait ~30s for CRE reveal + Gemini banker
+zsh scripts/play-game.sh state <GID>    # Should be BankerOffer (5)
+zsh scripts/play-game.sh reject <GID>
+
+zsh scripts/play-game.sh open <GID> 1
+# Wait ~30s
+zsh scripts/play-game.sh reject <GID>
+
+zsh scripts/play-game.sh open <GID> 2
+# Wait ~30s — goes to FinalRound (6)
+
+# 6. Final round — keep or swap
+zsh scripts/play-game.sh keep <GID>
+# Wait ~20s — CRE reveals remaining cases, GameOver
+
+# 7. Check final state
+zsh scripts/play-game.sh state <GID>    # Should be GameOver (8) with payout
+```
+
+## Full E2E Test (Browser Mode)
+
+```bash
+# Terminal 1: Frontend
+cd prototype/frontend && npm run dev
+
+# Terminal 2: CRE Support
+cd prototype && source scripts/env.sh
+# Create game in browser at localhost:3000, then:
+zsh scripts/cre-support.sh <GID>
+# Play in browser — script auto-handles everything
+```
+
+**Important**: Games created via `cast send` (deployer key) can only be played via `cast send`. Games created in the browser (MetaMask) can only be played in the browser. The addresses are different.
+
+## What Gets Tested
+
+| Feature | Verified By |
+|---|---|
+| VRF seed generation | Game advances from WaitingForVRF → Created |
+| Confidential HTTP entropy | `cre-reveal.sh` logs "CRE entropy fetched" |
+| Case value written on-chain | Game state shows `Collapsed: N` incrementing |
+| Gemini AI Banker personality | `cre-banker.sh` logs "Gemini returned: ..." |
+| BestOfBanker gallery save | `cre-banker.sh` logs "BestOfBanker saved: tx=..." |
+| Banker offer on-chain | Game state shows non-zero Banker Offer |
+| Final round event index | `keepCase`/`swapCase` → CRE reveal succeeds (event index 1) |
+| Game completion | Phase reaches GameOver (8) with final payout |
+
+## Gotchas We Hit (and their fixes)
+
+### 1. `NotCREForwarder` revert (the big one)
+
+**Symptom**: `cre simulate --broadcast` succeeds (simulation logs look perfect), but game state doesn't change. Forwarder TX has `status: 1` but `result: false`.
+
+**Root cause**: `creForwarder` on contract set to deployer address, not MockKeystoneForwarder.
+
+**Fix**: `cast send "$CONTRACT" "setCREForwarder(address)" 0x82300bd7c3958625581cc2F77bC6464dcEcDF3e5`
+
+### 2. `{{.geminiApiKey}}` template not resolved in simulate mode
+
+**Symptom**: Gemini returns "API key not valid" — the literal string `{{.geminiApiKey}}` was sent as the header.
+
+**Root cause**: ConfidentialHTTPClient template syntax is only resolved inside the real CRE enclave, not in simulate mode.
+
+**Fix**: `cre-banker.sh` temporarily injects the API key from `GEMINI_API_KEY_ALL` env var into `config.staging.json`, then restores it after the run. `gemini.ts` uses `runtime.config.geminiApiKey || "{{.geminiApiKey}}"` — config for simulate, template for production.
+
+### 3. Final round `invalid bigint literal`
+
+**Symptom**: CRE reveal fails with "invalid bigint literal" when processing `keepCase`/`swapCase` TX.
+
+**Root cause**: `keepCase()` emits `CaseKept` at log index 0 and `CaseOpenRequested` at log index 1. The script was passing event index 0 (correct for `openCase`, wrong for `keepCase`).
+
+**Fix**: `cre-support.sh` passes `EVENT_IDX=1` for WaitingFinalCRE (phase 7).
+
+### 4. `replacement transaction underpriced` on BestOfBanker
+
+**Symptom**: Second `writeReport` in banker-ai workflow fails with nonce collision.
+
+**Root cause**: Two rapid `writeReport` calls in the same workflow (game contract + BestOfBanker) — the CRE simulate mode sometimes reuses the same nonce.
+
+**Status**: Non-critical — the game offer still goes through. BestOfBanker save is in a try/catch. Sometimes works, sometimes doesn't. Asking Chainlink devrel about patterns for multiple writes.
+
+### 5. Static WorkflowExecutionID (potential future issue)
+
+**Symptom**: After many games, `cre simulate --broadcast` may silently fail — forwarder rejects the report.
+
+**Root cause**: MockKeystoneForwarder tracks `(receiver, executionId, reportId)` tuples for replay protection. The `executionId` is static per workflow in simulate mode.
+
+**Workaround per Thomas (Chainlink devrel)**: Redeploy receiver contract. He's providing feedback to the team about static executionIds.
+
+### 6. mathjs.org scientific notation
+
+**Symptom**: `BigInt()` throws "invalid bigint literal" when mathjs returns `4.43e+5`.
+
+**Fix**: Already handled in `confidential-reveal/main.ts` with `BigInt(Math.floor(Number(entropyText.trim())))`.
+
+## Event Index Reference
+
+| TX Source | Log 0 | Log 1 | Log 2 |
+|---|---|---|---|
+| `openCase()` | CaseOpenRequested | — | — |
+| `keepCase()` | CaseKept | CaseOpenRequested | — |
+| `swapCase()` | CaseSwapped | CaseOpenRequested | — |
+| CRE reveal TX | CaseRevealed | RoundComplete | ForwarderEvent |
+
+## Contract Addresses (Base Sepolia)
+
+| Contract | Address | Forwarder Set? |
+|---|---|---|
+| DealOrNotConfidential | `0xd9D4A974021055c46fD834049e36c21D7EE48137` | Yes (2026-03-06) |
+| BestOfBanker | `0x05EdC924f92aBCbbB91737479948509dC7E23bF9` | Yes |
+| SponsorJackpot | `0xc6b4Ba33f59816F1B47818EFf928e9a48F7ddC95` | Check |
+| MockKeystoneForwarder | `0x82300bd7c3958625581cc2F77bC6464dcEcDF3e5` | N/A |
+
+## CRE Workflow Architecture
+
+```
+Player: openCase(gameId, caseIndex)
+  → CaseOpenRequested event (log index 0)
+    → CRE #1: confidential-reveal
+        Confidential HTTP → mathjs.org randomInt (entropy)
+        hash(vrfSeed, caseIndex, usedBitmap, creEntropy) → value
+        writeReport → fulfillCaseValue()
+    → CRE #2: sponsor-jackpot (optional, needs sponsor registered)
+  → CaseRevealed + RoundComplete events
+    → CRE #3: banker-ai
+        Read game state → compute EV offer
+        Confidential HTTP → Gemini 2.5 Flash (snarky message)
+        writeReport #1 → setBankerOfferWithMessage() (game contract)
+        writeReport #2 → saveQuote() (BestOfBanker gallery)
+
+Player: keepCase() / swapCase()
+  → CaseKept/CaseSwapped (log 0) + CaseOpenRequested (log 1)
+    → CRE #1: confidential-reveal (event index 1, not 0!)
+    → No banker in FinalRound
+  → GameOver
+```

--- a/prototype/scripts/cre-banker.sh
+++ b/prototype/scripts/cre-banker.sh
@@ -6,9 +6,9 @@
 # RoundComplete is typically at log index 1 in the reveal tx
 # (log 0 = CaseRevealed, log 1 = RoundComplete, log 2 = forwarder).
 #
-# Gemini API key: loaded via Vault DON secrets (Confidential HTTP).
-# In simulate mode, CRE reads from secrets.yaml -> env var GEMINI_API_KEY_ALL.
-# The key is injected inside the enclave — no DON node sees it.
+# Gemini API key: In production, injected via Vault DON secrets (Confidential HTTP).
+# In simulate mode, the {{.geminiApiKey}} template isn't resolved, so this script
+# temporarily injects the key from GEMINI_API_KEY_ALL env var into config.staging.json.
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/env.sh"
@@ -23,6 +23,26 @@ echo "  TX:    $TX_HASH"
 echo "  Event: log index $EVENT_INDEX (RoundComplete)"
 
 cd "$SCRIPT_DIR/../workflows"
+
+# Inject Gemini API key into config for simulate mode, restore on exit
+CONFIG="banker-ai/config.staging.json"
+BACKUP=""
+if [[ -n "$GEMINI_API_KEY_ALL" ]]; then
+  BACKUP=$(cat "$CONFIG")
+  python3 -c "
+import json
+with open('$CONFIG') as f:
+    c = json.load(f)
+c['geminiApiKey'] = '${GEMINI_API_KEY_ALL}'
+with open('$CONFIG', 'w') as f:
+    json.dump(c, f, indent=2)
+"
+  trap 'echo "$BACKUP" > "$CONFIG"' EXIT
+  echo "  Config: Gemini API key injected (will restore on exit)"
+else
+  echo "  WARNING: No GEMINI_API_KEY_ALL — Gemini will use fallback message"
+fi
+
 cre workflow simulate ./banker-ai \
   --evm-tx-hash "$TX_HASH" \
   --evm-event-index "$EVENT_INDEX" \

--- a/prototype/scripts/cre-support.sh
+++ b/prototype/scripts/cre-support.sh
@@ -139,14 +139,18 @@ while true; do
           LAST_REVEAL_OPEN_TX="$OPEN_TX"
           echo "  Found openCase TX: $OPEN_TX"
 
+          # keepCase/swapCase emit CaseKept/CaseSwapped at log 0, CaseOpenRequested at log 1
+          # openCase emits CaseOpenRequested at log 0
+          [[ "$PHASE" == "7" ]] && EVENT_IDX=1 || EVENT_IDX=0
+
           echo ""
           echo "  +-- cre-reveal.sh -----"
-          "$SCRIPT_DIR/cre-reveal.sh" "$OPEN_TX" 2>&1 | sed 's/^/  | /' || echo "  | reveal failed"
+          "$SCRIPT_DIR/cre-reveal.sh" "$OPEN_TX" "$EVENT_IDX" 2>&1 | sed 's/^/  | /' || echo "  | reveal failed"
           echo "  +----------------------"
 
           echo ""
           echo "  +-- cre-jackpot.sh (optional) -----"
-          "$SCRIPT_DIR/cre-jackpot.sh" "$OPEN_TX" 2>&1 | sed 's/^/  | /' || echo "  | (jackpot skipped -- non-critical)"
+          "$SCRIPT_DIR/cre-jackpot.sh" "$OPEN_TX" "$EVENT_IDX" 2>&1 | sed 's/^/  | /' || echo "  | (jackpot skipped -- non-critical)"
           echo "  | No jackpot? Run: cast send \$SPONSOR_JACKPOT \"registerSponsor(string,string)\" \"Name\" \"\" --value 0.01ether"
           echo "  | Then: cast send \$SPONSOR_JACKPOT \"sponsorGame(uint256)\" $GAME_ID"
           echo "  +----------------------------------"

--- a/prototype/workflows/banker-ai/gemini.ts
+++ b/prototype/workflows/banker-ai/gemini.ts
@@ -124,7 +124,7 @@ export function callGemini(
           bodyString,
           multiHeaders: {
             "Content-Type": { values: ["application/json"] },
-            "x-goog-api-key": { values: ["{{.geminiApiKey}}"] },
+            "x-goog-api-key": { values: [runtime.config.geminiApiKey || "{{.geminiApiKey}}"] },
           },
         },
         vaultDonSecrets: [


### PR DESCRIPTION
## Summary

- **Bash-compatible scripts**: Rewrote all CRE shell scripts (`cre-support.sh`, `cre-reveal.sh`, `cre-banker.sh`, `cre-jackpot.sh`) to use bash-compatible syntax, added preflight checks, and added CRE `project.yaml`
- **Confidential HTTP for CRE entropy + Gemini**: Switched `confidential-reveal` workflow to use `ConfidentialHTTPClient` for entropy (mathjs.org). Added Gemini API key injection for simulate mode (`config.staging.json` fallback pattern)
- **Final round event index fix**: `keepCase()`/`swapCase()` emit `CaseOpenRequested` at log index 1, not 0. `cre-support.sh` now passes `EVENT_IDX=1` for phase 7 (WaitingFinalCRE)
- **Stale docs rewrite**: Updated `README_TESTING.md`, contracts README, and added comprehensive `TESTCASE_CONFIDENTIAL.md` with full E2E walkthrough and all gotchas
- **E2E verified**: Full 5-case game played through with CRE confidential reveals, Gemini AI banker messages, BestOfBanker gallery saves, and GameOver payout

## Key fixes

| Issue | Root Cause | Fix |
|---|---|---|
| `NotCREForwarder` revert | `creForwarder` pointed to deployer, not MockKeystoneForwarder | `setCREForwarder(0x82300bd7...)` post-deploy |
| Gemini API key invalid | `{{.geminiApiKey}}` template not resolved in simulate mode | Config fallback + `cre-banker.sh` key injection |
| Final round `invalid bigint` | Wrong event index for `keepCase`/`swapCase` | `EVENT_IDX=1` for phase 7 |

## Test plan

- [ ] `source scripts/env.sh && zsh scripts/play-game.sh create` → game created
- [ ] `zsh scripts/cre-support.sh <GID>` → auto-handles reveals, banker, jackpot
- [ ] Full 5-case game reaches GameOver (phase 8) with payout
- [ ] Gemini banker messages appear on-chain
- [ ] See `TESTCASE_CONFIDENTIAL.md` for detailed steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)