### PR TITLE
feat: Add query param strategy switcher (3 strategies)

### DIFF
--- a/prototype/agent-server/index.ts
+++ b/prototype/agent-server/index.ts
@@ -1,21 +1,21 @@
 /**
- * Demo Agent Server — EV Maximizer Strategy
+ * Demo Agent Server — Multi-Strategy Support
  *
  * Simple Bun HTTP server that plays Deal or NOT autonomously.
  * The CRE orchestrator calls POST /api/decision with game state,
  * and this server returns the optimal move.
  *
- * Strategies:
- *   Created phase  → pick random case
- *   Round phase    → open the case most likely to be low value
- *   BankerOffer    → accept if offer >= 80% of expected value
- *   FinalRound     → keep case (conservative)
+ * Strategies (configurable via query param ?strategy=):
+ *   - random: Completely random decisions (baseline)
+ *   - ev-maximizer: Pure game theory, accept offers > EV (default)
+ *   - risk-averse: Conservative, accept offers >= 90% of EV
  *
  * Usage: bun run index.ts
  * Port: 3001 (or PORT env var)
  */
 
 const PORT = Number(process.env.PORT) || 3001;
+const DEFAULT_STRATEGY = process.env.STRATEGY || "ev-maximizer";
 
 type DecisionRequest = {
   gameId: string;
@@ -38,63 +38,220 @@ type DecisionResponse = {
   reasoning: string;
 };
 
-function decide(req: DecisionRequest): DecisionResponse {
-  const { phase, gameState, expectedValue } = req;
-  const { playerCase, opened, bankerOffer } = gameState;
+// ── Strategy Interface ──
 
-  switch (phase) {
-    case "Created": {
-      // Pick a random case (0-4)
-      const pick = Math.floor(Math.random() * 5);
-      return {
-        action: "pick",
-        caseIndex: pick,
-        reasoning: `Picking case ${pick} (random selection)`,
-      };
-    }
+interface Strategy {
+  name: string;
+  decide(req: DecisionRequest): DecisionResponse;
+}
 
-    case "Round": {
-      // Open a case that isn't ours and isn't already opened
-      for (let i = 0; i < 5; i++) {
-        if (i !== playerCase && !opened[i]) {
-          return {
-            action: "open",
-            caseIndex: i,
-            reasoning: `Opening case ${i} (first available)`,
-          };
-        }
-      }
-      throw new Error("No cases available to open");
-    }
+// ── Random Strategy (Baseline) ──
 
-    case "BankerOffer": {
-      // Accept if offer >= 80% of EV
-      const threshold = expectedValue * 0.8;
-      if (bankerOffer >= threshold) {
+class RandomStrategy implements Strategy {
+  name = "Random";
+
+  decide(req: DecisionRequest): DecisionResponse {
+    const { phase, gameState, expectedValue } = req;
+    const { playerCase, opened, bankerOffer } = gameState;
+
+    switch (phase) {
+      case "Created": {
+        const pick = Math.floor(Math.random() * 5);
         return {
-          action: "deal",
-          reasoning: `Accepting offer ${bankerOffer}c (>= 80% of EV ${expectedValue.toFixed(1)}c)`,
+          action: "pick",
+          caseIndex: pick,
+          reasoning: `[Random] Picking case ${pick}`,
         };
       }
-      return {
-        action: "no-deal",
-        reasoning: `Rejecting offer ${bankerOffer}c (< 80% of EV ${expectedValue.toFixed(1)}c)`,
-      };
-    }
 
-    case "FinalRound": {
-      // Conservative: keep our case
-      return {
-        action: "keep",
-        reasoning: "Keeping our case (conservative strategy)",
-      };
-    }
+      case "Round": {
+        // Random available case
+        const available = [];
+        for (let i = 0; i < 5; i++) {
+          if (i !== playerCase && !opened[i]) available.push(i);
+        }
+        if (available.length === 0) throw new Error("No cases available");
+        const pick = available[Math.floor(Math.random() * available.length)];
+        return {
+          action: "open",
+          caseIndex: pick,
+          reasoning: `[Random] Opening case ${pick}`,
+        };
+      }
 
+      case "BankerOffer": {
+        const accept = Math.random() > 0.5;
+        return {
+          action: accept ? "deal" : "no-deal",
+          reasoning: accept
+            ? `[Random] Accepting ${bankerOffer}c (50/50 coin flip)`
+            : `[Random] Rejecting ${bankerOffer}c (50/50 coin flip)`,
+        };
+      }
+
+      case "FinalRound": {
+        const keep = Math.random() > 0.5;
+        return {
+          action: keep ? "keep" : "swap",
+          reasoning: keep
+            ? "[Random] Keeping case (coin flip)"
+            : "[Random] Swapping case (coin flip)",
+        };
+      }
+
+      default:
+        return {
+          action: "keep",
+          reasoning: `[Random] Unknown phase: ${phase}`,
+        };
+    }
+  }
+}
+
+// ── EV Maximizer Strategy (Pure Game Theory) ──
+
+class EVMaximizerStrategy implements Strategy {
+  name = "EV Maximizer";
+
+  decide(req: DecisionRequest): DecisionResponse {
+    const { phase, gameState, expectedValue } = req;
+    const { playerCase, opened, bankerOffer } = gameState;
+
+    switch (phase) {
+      case "Created": {
+        const pick = Math.floor(Math.random() * 5);
+        return {
+          action: "pick",
+          caseIndex: pick,
+          reasoning: `[EV Max] Picking case ${pick} (random start)`,
+        };
+      }
+
+      case "Round": {
+        // Open first available (no information advantage)
+        for (let i = 0; i < 5; i++) {
+          if (i !== playerCase && !opened[i]) {
+            return {
+              action: "open",
+              caseIndex: i,
+              reasoning: `[EV Max] Opening case ${i} (first available)`,
+            };
+          }
+        }
+        throw new Error("No cases available");
+      }
+
+      case "BankerOffer": {
+        // Accept only if offer > EV (pure game theory)
+        if (bankerOffer > expectedValue) {
+          return {
+            action: "deal",
+            reasoning: `[EV Max] Accepting ${bankerOffer}c (> EV ${expectedValue.toFixed(1)}c, +${(bankerOffer - expectedValue).toFixed(1)}c edge)`,
+          };
+        }
+        return {
+          action: "no-deal",
+          reasoning: `[EV Max] Rejecting ${bankerOffer}c (<= EV ${expectedValue.toFixed(1)}c)`,
+        };
+      }
+
+      case "FinalRound": {
+        // No information advantage, keep case (default)
+        return {
+          action: "keep",
+          reasoning: "[EV Max] Keeping case (50/50, no edge)",
+        };
+      }
+
+      default:
+        return {
+          action: "keep",
+          reasoning: `[EV Max] Unknown phase: ${phase}`,
+        };
+    }
+  }
+}
+
+// ── Risk-Averse Strategy (Conservative) ──
+
+class RiskAverseStrategy implements Strategy {
+  name = "Risk-Averse";
+
+  decide(req: DecisionRequest): DecisionResponse {
+    const { phase, gameState, expectedValue } = req;
+    const { playerCase, opened, bankerOffer } = gameState;
+
+    switch (phase) {
+      case "Created": {
+        const pick = Math.floor(Math.random() * 5);
+        return {
+          action: "pick",
+          caseIndex: pick,
+          reasoning: `[Risk-Averse] Picking case ${pick} (random start)`,
+        };
+      }
+
+      case "Round": {
+        // Open first available
+        for (let i = 0; i < 5; i++) {
+          if (i !== playerCase && !opened[i]) {
+            return {
+              action: "open",
+              caseIndex: i,
+              reasoning: `[Risk-Averse] Opening case ${i} (first available)`,
+            };
+          }
+        }
+        throw new Error("No cases available");
+      }
+
+      case "BankerOffer": {
+        // Accept if offer >= 90% of EV (conservative)
+        const threshold = expectedValue * 0.9;
+        if (bankerOffer >= threshold) {
+          return {
+            action: "deal",
+            reasoning: `[Risk-Averse] Accepting ${bankerOffer}c (>= 90% of EV ${expectedValue.toFixed(1)}c, locking in gains)`,
+          };
+        }
+        return {
+          action: "no-deal",
+          reasoning: `[Risk-Averse] Rejecting ${bankerOffer}c (< 90% of EV ${expectedValue.toFixed(1)}c)`,
+        };
+      }
+
+      case "FinalRound": {
+        // Conservative: keep case
+        return {
+          action: "keep",
+          reasoning: "[Risk-Averse] Keeping case (conservative choice)",
+        };
+      }
+
+      default:
+        return {
+          action: "keep",
+          reasoning: `[Risk-Averse] Unknown phase: ${phase}`,
+        };
+    }
+  }
+}
+
+// ── Strategy Factory ──
+
+function getStrategy(strategyName: string): Strategy {
+  switch (strategyName.toLowerCase()) {
+    case "random":
+      return new RandomStrategy();
+    case "ev-maximizer":
+    case "ev":
+      return new EVMaximizerStrategy();
+    case "risk-averse":
+    case "conservative":
+      return new RiskAverseStrategy();
     default:
-      return {
-        action: "keep",
-        reasoning: `Unknown phase: ${phase}, defaulting to keep`,
-      };
+      console.warn(`Unknown strategy: ${strategyName}, defaulting to ev-maximizer`);
+      return new EVMaximizerStrategy();
   }
 }
 
@@ -105,16 +262,28 @@ const server = Bun.serve({
 
     // Health check
     if (url.pathname === "/" || url.pathname === "/health") {
-      return Response.json({ status: "ok", agent: "EV Maximizer", version: "1.0" });
+      const strategyParam = url.searchParams.get("strategy");
+      const strategy = getStrategy(strategyParam || DEFAULT_STRATEGY);
+      return Response.json({
+        status: "ok",
+        agent: strategy.name,
+        version: "2.0",
+        availableStrategies: ["random", "ev-maximizer", "risk-averse"]
+      });
     }
 
     // Decision endpoint
     if (url.pathname === "/api/decision" && request.method === "POST") {
       return request.json().then((body: unknown) => {
         const req = body as DecisionRequest;
-        console.log(`Game ${req.gameId} | Phase: ${req.phase} | EV: ${req.expectedValue?.toFixed(1)}c`);
 
-        const decision = decide(req);
+        // Read strategy from query param, fall back to env
+        const strategyParam = url.searchParams.get("strategy");
+        const strategy = getStrategy(strategyParam || DEFAULT_STRATEGY);
+
+        console.log(`[${strategy.name}] Game ${req.gameId} | Phase: ${req.phase} | EV: ${req.expectedValue?.toFixed(1)}c`);
+
+        const decision = strategy.decide(req);
         console.log(`  -> ${decision.action}${decision.caseIndex !== undefined ? ` case=${decision.caseIndex}` : ""} | ${decision.reasoning}`);
 
         return Response.json(decision);
@@ -128,5 +297,10 @@ const server = Bun.serve({
 });
 
 console.log(`Agent server running on http://localhost:${server.port}`);
-console.log("Strategy: EV Maximizer (accept deals >= 80% EV)");
-console.log("Endpoint: POST /api/decision");
+console.log(`Default strategy: ${DEFAULT_STRATEGY}`);
+console.log("Available strategies: random, ev-maximizer, risk-averse");
+console.log("Usage: POST /api/decision?strategy=<strategy>");
+console.log("Examples:");
+console.log("  - /api/decision?strategy=random");
+console.log("  - /api/decision?strategy=ev-maximizer");
+console.log("  - /api/decision?strategy=risk-averse");


### PR DESCRIPTION
## Summary

Implements query param support for selecting agent strategies as requested by @tippi-fifestarr in https://github.com/rdobbeck/deal-or-not/pull/17#issuecomment-4017730030.

## What's Included

### Query Param Support
- `?strategy=random` - Random baseline strategy
- `?strategy=ev-maximizer` - Pure game theory (default)
- `?strategy=risk-averse` - Conservative (90% EV threshold)
- Falls back to `STRATEGY` env var if no query param provided

### Three Strategies Implemented

**1. Random** (Baseline)
- Random case selection
- 50/50 deal/no-deal decisions
- 50/50 keep/swap in final round

**2. EV Maximizer** (Game Theory)
- Accept offers **only if** offer > expected value
- Maximizes long-term winnings
- No risk adjustment

**3. Risk-Averse** (Conservative)
- Accept offers if >= 90% of expected value
- Locks in gains earlier
- Conservative keep strategy in final round

## Usage

Register 3 agents in AgentRegistry with different URLs pointing to the same Railway deployment:

```
Agent 1 (Random):
https://keen-forgiveness-production.up.railway.app/api/decision?strategy=random

Agent 2 (EV Maximizer):
https://keen-forgiveness-production.up.railway.app/api/decision?strategy=ev-maximizer

Agent 3 (Risk-Averse):
https://keen-forgiveness-production.up.railway.app/api/decision?strategy=risk-averse
```

## Testing

All 3 strategies tested locally:

```bash
# EV Maximizer: Accepted 50c (> 33.2c EV)
curl -X POST "http://localhost:3001/api/decision?strategy=ev-maximizer" \
  -d '{"gameId":"test","phase":"BankerOffer","expectedValue":33.2,"bankerOffer":50,...}'
# {"action":"deal","reasoning":"[EV Max] Accepting 50c (> EV 33.2c, +16.8c edge)"}

# Risk-Averse: Accepted 30c (90% of 33.2c EV)
curl -X POST "http://localhost:3001/api/decision?strategy=risk-averse" \
  -d '{"gameId":"test","phase":"BankerOffer","expectedValue":33.2,"bankerOffer":30,...}'
# {"action":"deal","reasoning":"[Risk-Averse] Accepting 30c (>= 90% of EV 33.2c, locking in gains)"}

# Random: Random case selection
curl -X POST "http://localhost:3001/api/decision?strategy=random" \
  -d '{"gameId":"test","phase":"Created",...}'
# {"action":"pick","caseIndex":1,"reasoning":"[Random] Picking case 1"}
```

## Deployment

Once merged and deployed to Railway, the 3 agent URLs will be ready for registration in AgentRegistry.

**Ready for E2E testing with CRE orchestrator!** 🚀