### PR TITLE
fix: Display game ID in status component

### DIFF
--- a/prototype/frontend/app/watch/[id]/page.tsx
+++ b/prototype/frontend/app/watch/[id]/page.tsx
@@ -114,6 +114,7 @@ export default function WatchGame({ params }: { params: Promise<{ id: string }> 
             phase={phase.toString()}
             round={gameState.currentRound}
             maxRounds={4}
+            gameId={gameId}
             onClick={phase === Phase.BankerOffer && bankerOfferDismissed ? () => setBankerOfferDismissed(false) : undefined}
           />
 

--- a/prototype/frontend/components/game/GameBoard.tsx
+++ b/prototype/frontend/components/game/GameBoard.tsx
@@ -480,6 +480,7 @@ export default function GameBoard() {
         phase={phase.toString()}
         round={gameState.currentRound}
         maxRounds={4}
+        gameId={gameId}
         playerAddress={isPlayer ? gameState.player : undefined}
         onClick={phase === Phase.BankerOffer && bankerOfferDismissed ? () => setBankerOfferDismissed(false) : undefined}
       />

--- a/prototype/frontend/components/glass/GlassGameStatus.tsx
+++ b/prototype/frontend/components/glass/GlassGameStatus.tsx
@@ -12,6 +12,7 @@ interface GlassGameStatusProps {
   phase: string;
   round?: number;
   maxRounds?: number;
+  gameId?: bigint | number;
   playerAddress?: string;
   className?: string;
   onClick?: () => void;
@@ -21,6 +22,7 @@ export function GlassGameStatus({
   phase,
   round,
   maxRounds = 4,
+  gameId,
   playerAddress,
   className,
   onClick,
@@ -66,7 +68,7 @@ export function GlassGameStatus({
       <div className="flex items-center justify-between">
         <div className="space-y-1">
           <div className="text-sm text-white/60 uppercase tracking-wider">
-            Game Status
+            {gameId !== undefined ? `Game #${gameId.toString()}` : "Game Status"}
           </div>
           <div className="text-2xl font-bold text-white">
             {getPhaseText()}


### PR DESCRIPTION
## Summary
- Players couldn't tell which game number they were in during gameplay
- Added `gameId` prop to `GlassGameStatus` component — displays "Game #N" in the status header
- Updated both player view (`GameBoard`) and spectator view (`watch/[id]`) to pass the game ID

## Test plan
- [ ] Start a new game and verify "Game #N" appears in the status card
- [ ] Watch a game as spectator and verify "Game #N" appears
- [ ] Verify fallback text "Game Status" still shows when no gameId is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)